### PR TITLE
fix linux booting error: s3fs_init could not load IAM role name from …

### DIFF
--- a/User_data_Linux_Amazon.sh
+++ b/User_data_Linux_Amazon.sh
@@ -36,5 +36,5 @@ yum install s3fs-fuse -y
 mkdir $MOUNT
 s3fs -o allow_other -o iam_role=auto -o endpoint=$REGION -o url="https://s3-$REGION.amazonaws.com" $BUCKET $MOUNT
 
-echo "s3fs#$BUCKET $MOUNT fuse allow_other,nonempty,use_path_request_style,iam_role=auto,url=https://s3-$REGION.amazonaws.com,endpoint=$REGION 0 0" >> /etc/fstab
+echo "s3fs#$BUCKET $MOUNT fuse _netdev,allow_other,nonempty,use_path_request_style,iam_role=auto,url=https://s3-$REGION.amazonaws.com,endpoint=$REGION 0 0" >> /etc/fstab
 


### PR DESCRIPTION
My instance based on Amazon Linux 2023
Currently I've got an error after reboot (in syslog): s3fs_init could not load IAM role name from meta data

I've added the **_netdev** (found the solution here: https://serverfault.com/questions/441691/how-to-make-s3fs-work-with-iam-roles) and it works!